### PR TITLE
Fix interfaces typo errors

### DIFF
--- a/contracts/facets/GettersFacet.sol
+++ b/contracts/facets/GettersFacet.sol
@@ -513,7 +513,7 @@ contract GettersFacet is IGetters {
     /// @param termId The term id for which the APY is being calculated
     /// @param user The user for which the APY is being calculated
     /// @return The APY for the user
-    function userAPY(uint termId, address user) external returns (uint256) {
+    function userAPY(uint termId, address user) external view returns (uint256) {
         LibYieldGenerationStorage.YieldGeneration storage yield = LibYieldGenerationStorage
             ._yieldStorage()
             .yields[termId];
@@ -528,7 +528,7 @@ contract GettersFacet is IGetters {
     /// @notice This function is used to get a term APY
     /// @param termId The term id for which the APY is being calculated
     /// @return The APY for the term
-    function termAPY(uint termId) external returns (uint256) {
+    function termAPY(uint termId) external view returns (uint256) {
         LibYieldGenerationStorage.YieldGeneration storage yield = LibYieldGenerationStorage
             ._yieldStorage()
             .yields[termId];
@@ -560,7 +560,7 @@ contract GettersFacet is IGetters {
     /// @notice This function is used to get the total yield generated for a term
     /// @param termId The term id for which the yield is being calculated
     /// @return The total yield generated for the term
-    function totalYieldGenerated(uint termId) public returns (uint) {
+    function totalYieldGenerated(uint termId) public view returns (uint) {
         LibYieldGenerationStorage.YieldGeneration storage yield = LibYieldGenerationStorage
             ._yieldStorage()
             .yields[termId];
@@ -594,7 +594,7 @@ contract GettersFacet is IGetters {
     /// @param termId The term id for which the yield is being calculated
     /// @param user The user for which the yield is being calculated
     /// @return The total yield generated for the user
-    function userYieldGenerated(uint termId, address user) public returns (uint) {
+    function userYieldGenerated(uint termId, address user) public view returns (uint) {
         LibYieldGenerationStorage.YieldGeneration storage yield = LibYieldGenerationStorage
             ._yieldStorage()
             .yields[termId];

--- a/contracts/interfaces/IGetters.sol
+++ b/contracts/interfaces/IGetters.sol
@@ -173,15 +173,15 @@ interface IGetters {
 
     function userHasoptedInYG(uint termId, address user) external view returns (bool);
 
-    function userAPY(uint termId, address user) external returns (uint256);
+    function userAPY(uint termId, address user) external view returns (uint256);
 
-    function termAPY(uint termId) external returns (uint256);
+    function termAPY(uint termId) external view returns (uint256);
 
     function yieldDistributionRatio(uint termId, address user) external view returns (uint256);
 
-    function totalYieldGenerated(uint termId) external returns (uint);
+    function totalYieldGenerated(uint termId) external view returns (uint);
 
-    function userYieldGenerated(uint termId, address user) external returns (uint);
+    function userYieldGenerated(uint termId, address user) external view returns (uint);
 
     function getYieldLockState() external view returns (bool);
 

--- a/contracts/interfaces/IZaynVaultV2TakaDao.sol
+++ b/contracts/interfaces/IZaynVaultV2TakaDao.sol
@@ -8,13 +8,13 @@ interface IZaynVaultV2TakaDao {
 
     function withdrawZap(uint256 _shares, uint256 _term) external;
 
-    function want() external pure returns (address);
+    function want() external view returns (address);
 
-    function balance() external pure returns (uint256);
+    function balance() external view returns (uint256);
 
-    function strategy() external pure returns (address);
+    function strategy() external view returns (address);
 
-    function balanceOf(uint256 term) external returns (uint256);
+    function balanceOf(uint256 term) external view returns (uint256);
 
     function getPricePerFullShare() external view returns (uint256);
 }


### PR DESCRIPTION
Fix typo errors on provided interface according the deployed code. This allowed to make some of our functions view
Related to git issue #135 