### PR TITLE
revise: backward compatibility deploy

### DIFF
--- a/contracts/facets/TermFacet.sol
+++ b/contracts/facets/TermFacet.sol
@@ -27,9 +27,15 @@ contract TermFacet is ITerm {
         uint indexed termId,
         address payer,
         address indexed user,
+        uint amount
+    ); // TODO: To be deprecated, here to ensure backwards compatibility with the old event
+    event OnCollateralDepositedNext(
+        uint indexed termId,
+        address payer,
+        address indexed user,
         uint amount,
         uint indexed position
-    ); // Emits when a user joins a term
+    ); // Emits when a user joins a term // Todo: To be renamed to OnCollateralDeposited
     event OnTermFilled(uint indexed termId); // Emits when all the spots are filled
     event OnTermExpired(uint indexed termId); // Emits when a term expires
     event OnTermStart(uint indexed termId); // Emits when a new term starts, this also marks the start of the first cycle
@@ -72,7 +78,8 @@ contract TermFacet is ITerm {
     /// @param termId The id of the term
     /// @param optYield Whether the participant wants to opt in for yield generation
     /// @param position The position in the term
-    function joinTerm(uint termId, bool optYield, uint position) external payable {
+    // TODO: To be renamed to joinTerm, this name only to ensure backwards compatibility
+    function joinTermNext(uint termId, bool optYield, uint position) external payable {
         _joinTermByPosition(termId, optYield, position, msg.sender);
     }
 
@@ -262,7 +269,9 @@ contract TermFacet is ITerm {
             yield.hasOptedIn[_newParticipant] = false;
         }
 
-        emit OnCollateralDeposited(_termId, msg.sender, _newParticipant, msg.value, _position);
+        // TODO: Emit both events to ensure backwards compatibility
+        emit OnCollateralDeposited(_termId, msg.sender, _newParticipant, msg.value);
+        emit OnCollateralDepositedNext(_termId, msg.sender, _newParticipant, msg.value, _position);
 
         if (collateral.counterMembers == 1) {
             collateral.firstDepositTime = block.timestamp;

--- a/contracts/interfaces/ITerm.sol
+++ b/contracts/interfaces/ITerm.sol
@@ -29,7 +29,7 @@ interface ITerm {
     /// @param termId The id of the term
     /// @param optYield Whether the participant wants to opt in for yield generation
     /// @param position The position in the term
-    function joinTerm(uint termId, bool optYield, uint position) external payable;
+    function joinTermNext(uint termId, bool optYield, uint position) external payable;
 
     /// @notice Pay security deposit on behalf of someone else, at the next available position
     /// @param termId The id of the term

--- a/test/integration/00-end-to-end.test.js
+++ b/test/integration/00-end-to-end.test.js
@@ -273,7 +273,7 @@ const { ZeroAddress } = require("ethers")
                                   .connect(accounts[i])
                                   ["joinTerm(uint256,bool)"](termId, true, { value: entrance })
                           )
-                              .to.emit(takaturnDiamond, "OnCollateralDeposited")
+                              .to.emit(takaturnDiamond, "OnCollateralDepositedNext")
                               .withArgs(
                                   termId,
                                   accounts[i].address,
@@ -305,7 +305,7 @@ const { ZeroAddress } = require("ethers")
                                       value: entrance,
                                   })
                           )
-                              .to.emit(takaturnDiamond, "OnCollateralDeposited")
+                              .to.emit(takaturnDiamond, "OnCollateralDepositedNext")
                               .withArgs(
                                   termId,
                                   accounts[i].address,
@@ -340,7 +340,7 @@ const { ZeroAddress } = require("ethers")
                                   .connect(accounts[i])
                                   ["joinTerm(uint256,bool)"](termId, false, { value: entrance })
                           )
-                              .to.emit(takaturnDiamond, "OnCollateralDeposited")
+                              .to.emit(takaturnDiamond, "OnCollateralDepositedNext")
                               .withArgs(
                                   termId,
                                   accounts[i].address,

--- a/test/unit/01-by-facet/01-term-facet.test.js
+++ b/test/unit/01-by-facet/01-term-facet.test.js
@@ -191,7 +191,7 @@ const { hour } = require("../../../utils/units")
                           takaturnDiamond
                               .connect(participant_1)
                               ["joinTerm(uint256,bool)"](termId, false, { value: entrance })
-                      ).to.emit(takaturnDiamond, "OnCollateralDeposited")
+                      ).to.emit(takaturnDiamond, "OnCollateralDepositedNext")
 
                       const participantSummary =
                           await takaturnDiamond.getDepositorCollateralSummary(participant_1, termId)
@@ -323,7 +323,7 @@ const { hour } = require("../../../utils/units")
                   // Join
                   await takaturnDiamond
                       .connect(participant_1)
-                      ["joinTerm(uint256,bool,uint256)"](termId, false, position, {
+                      ["joinTermNext(uint256,bool,uint256)"](termId, false, position, {
                           value: entrance,
                       })
 
@@ -372,21 +372,21 @@ const { hour } = require("../../../utils/units")
                   await expect(
                       takaturnDiamond
                           .connect(participant_1)
-                          ["joinTerm(uint256,bool,uint256)"](termId, false, position, {
+                          ["joinTermNext(uint256,bool,uint256)"](termId, false, position, {
                               value: positionsAndDeposits[1][positionIndex + 1],
                           })
                   ).to.be.revertedWith("Eth payment too low")
 
                   await takaturnDiamond
                       .connect(participant_1)
-                      ["joinTerm(uint256,bool,uint256)"](termId, false, position, {
+                      ["joinTermNext(uint256,bool,uint256)"](termId, false, position, {
                           value: entrance,
                       })
 
                   await expect(
                       takaturnDiamond
                           .connect(participant_12)
-                          ["joinTerm(uint256,bool,uint256)"](termId, false, position, {
+                          ["joinTermNext(uint256,bool,uint256)"](termId, false, position, {
                               value: entrance,
                           })
                   ).to.be.revertedWith("Position already taken")
@@ -409,14 +409,14 @@ const { hour } = require("../../../utils/units")
 
                       const joinTx = takaturnDiamond
                           .connect(accounts[i + 1])
-                          ["joinTerm(uint256,bool,uint256)"](termId, false, i, {
+                          ["joinTermNext(uint256,bool,uint256)"](termId, false, i, {
                               value: entrance,
                           })
 
                       if (i === totalParticipants - 1) {
                           await Promise.all([
                               expect(joinTx)
-                                  .to.emit(takaturnDiamond, "OnCollateralDeposited")
+                                  .to.emit(takaturnDiamond, "OnCollateralDepositedNext")
                                   .withArgs(
                                       termId,
                                       accounts[i + 1].address,
@@ -431,7 +431,7 @@ const { hour } = require("../../../utils/units")
                       } else {
                           await Promise.all([
                               expect(joinTx)
-                                  .to.emit(takaturnDiamond, "OnCollateralDeposited")
+                                  .to.emit(takaturnDiamond, "OnCollateralDepositedNext")
                                   .withArgs(
                                       termId,
                                       accounts[i + 1].address,
@@ -458,7 +458,7 @@ const { hour } = require("../../../utils/units")
                   await expect(
                       takaturnDiamond
                           .connect(participant_12)
-                          ["joinTerm(uint256,bool,uint256)"](termId, false, totalParticipants, {
+                          ["joinTermNext(uint256,bool,uint256)"](termId, false, totalParticipants, {
                               value: entrance,
                           })
                   ).to.be.revertedWith("Invalid position")
@@ -482,7 +482,7 @@ const { hour } = require("../../../utils/units")
                   await expect(
                       takaturnDiamond
                           .connect(participant_12)
-                          ["joinTerm(uint256,bool,uint256)"](termId, false, 0, {
+                          ["joinTermNext(uint256,bool,uint256)"](termId, false, 0, {
                               value: entrance,
                           })
                   ).to.be.revertedWith("Position already taken")
@@ -570,7 +570,7 @@ const { hour } = require("../../../utils/units")
                               participant_1,
                               { value: entrance }
                           )
-                      ).to.emit(takaturnDiamond, "OnCollateralDeposited")
+                      ).to.emit(takaturnDiamond, "OnCollateralDepositedNext")
 
                       const participantSummary =
                           await takaturnDiamond.getDepositorCollateralSummary(participant_1, termId)
@@ -823,7 +823,7 @@ const { hour } = require("../../../utils/units")
                       if (i === totalParticipants - 1) {
                           await Promise.all([
                               expect(joinTx)
-                                  .to.emit(takaturnDiamond, "OnCollateralDeposited")
+                                  .to.emit(takaturnDiamond, "OnCollateralDepositedNext")
                                   .withArgs(
                                       termId,
                                       deployer.address,
@@ -838,7 +838,7 @@ const { hour } = require("../../../utils/units")
                       } else {
                           await Promise.all([
                               expect(joinTx)
-                                  .to.emit(takaturnDiamond, "OnCollateralDeposited")
+                                  .to.emit(takaturnDiamond, "OnCollateralDepositedNext")
                                   .withArgs(
                                       termId,
                                       deployer.address,


### PR DESCRIPTION
To ensure backwards compatibility, if the deploy is going to be done now some changes needs to be made:
- Changed the name of the new joinTerm function to `joinTermNext` this way there is no ambiguous functions and the frontend dont need to change the contract call to use the normalized signature
- The legacy event "OnCollateralDeposited" is also emited withh the new one. The new one is now called "OnCollateralDepositedNext" 

There are some comments marked as `TODO` as this changes will be reverted on next deploy.

cc: @elallamTaka @kkharji 